### PR TITLE
Quick'n'dirty client certificate support for s_client

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -2027,7 +2027,7 @@ s_client_options() {
           [[ "$1" =~ secp192r1 ]] && options="${options//secp192r1/prime192v1}"
           [[ "$1" =~ secp256r1 ]] && options="${options//secp256r1/prime256v1}"
      fi
-     tm_out "$options"
+     tm_out "$options $keyopts"
 }
 
 ###### check code starts here ######


### PR DESCRIPTION
Usage:
$ export keyopts="-cert path/to/cert.pem -CAfile path/to/cert.pem"
$ ./testssl.sh [usual options]

cert.pem may be single file containing pem-encoded:
- certificate key (not encrypted)
- client certificate
- any number of intermediate certificates